### PR TITLE
Do not specify SSL version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@
 
 language: python
 python:
+  - 3.8
+  - 3.7
   - 3.6
   - 3.5
-  - 3.4
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ python =
     3.7: py37
     3.6: py36
     3.5: py35
-    3.4: py34
 
 [testenv:flake8]
 basepython=python

--- a/webchk/http.py
+++ b/webchk/http.py
@@ -62,7 +62,7 @@ def parse_url(url):
 def _http_connect(loc):
     """Connects to the host and returns an HTTP or HTTPS connections."""
     if loc.scheme == "https":
-        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_SSLv23)
+        ssl_context = ssl.SSLContext()
         return http.client.HTTPSConnection(loc.netloc, context=ssl_context)
     return http.client.HTTPConnection(loc.netloc)
 


### PR DESCRIPTION
ssl.SSLContext() will accept connections from a wider range of SSL and TLS versions if no protocal is specified.